### PR TITLE
Proposed fix to getSupportPrice()

### DIFF
--- a/Initial Condition Analysis Fix.ipynb
+++ b/Initial Condition Analysis Fix.ipynb
@@ -1,0 +1,221 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This analysis confirms a bug that showed up in private testnet testing. One of the branches of `getSupportPrice()` has a bug that bricks the market if triggered."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "WEI = 1\n",
+    "GWEI = 10**9\n",
+    "WHOLE = 10**18\n",
+    "\n",
+    "def wei_to_whole(amount):\n",
+    "    return amount // 10**18\n",
+    "\n",
+    "def gwei_to_whole(amount):\n",
+    "    return amount // 10**9\n",
+    "\n",
+    "def gwei_to_wei(amount):\n",
+    "    return amount * 10**9\n",
+    "\n",
+    "def wei_to_gwei(amount):\n",
+    "    return amount // 10**9\n",
+    "\n",
+    "def convert_support_price(price):\n",
+    "    \"\"\"Support price is ETH wei / MKT gwei. Convert to ETH whole / MKT whole\"\"\"\n",
+    "    # ETH gwei / MKT gwei\n",
+    "    price_gwei_to_gwei = wei_to_gwei(price)\n",
+    "    # Note units cancel\n",
+    "    price_whole_to_whole = price_gwei_to_gwei\n",
+    "    return price_whole_to_whole"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "PRICE_FLOOR = int(.001 * GWEI)\n",
+    "SPREAD = 110 # 10 %\n",
+    "LIST_REWARD = .000025 * WHOLE # MKT\n",
+    "STAKE = .01 * WHOLE # MKT\n",
+    "VOTE_BY = 7 # Days. Are units right?\n",
+    "BACKEND_PAYMENT = 5\n",
+    "MAKER_PAYMENT = 25\n",
+    "RESERVE_PAYMENT = 100 - BACKEND_PAYMENT - MAKER_PAYMENT\n",
+    "COST_PER_BYTE = 100 * GWEI # ETH"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here we have the creator block set to 0."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Initial creator transfer into reserve\n",
+    "CREATOR_SUPPORT = 10 * WHOLE # ETH\n",
+    "# Creator does their thing\n",
+    "CREATOR_BLOCK_SIZE = int(0 * WHOLE) # MKT"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "N_PATRONS = 10\n",
+    "# Support each patron provides\n",
+    "SUPPORT = 1000 * WHOLE # ETH\n",
+    "N_MAKERS = 1000\n",
+    "# This is number of listings *per* maker\n",
+    "N_LISTINGS_PER_MAKER = 100\n",
+    "# Size of an individual data purchase in ETH\n",
+    "PURCHASE_SIZE = 1000 * WHOLE # ETH\n",
+    "# Number of purchases\n",
+    "N_PURCHASES = 90"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "MARKET_TOTAL: 0, RESERVE: 10\n"
+     ]
+    }
+   ],
+   "source": [
+    "RESERVE = 0 # Initial reserve is empty\n",
+    "MARKET_TOTAL = 0 # No Market tokens at start\n",
+    "\n",
+    "MARKET_TOTAL += CREATOR_BLOCK_SIZE\n",
+    "# Creator deposits funds in reserve\n",
+    "RESERVE += CREATOR_SUPPORT\n",
+    "print(\"MARKET_TOTAL: %d, RESERVE: %d\" % (wei_to_whole(MARKET_TOTAL), wei_to_whole(RESERVE)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "coin_table = {}\n",
+    "# We're just going to use whole units for convenience\n",
+    "coin_table[\"CREATOR\"] = CREATOR_BLOCK_SIZE / 10**18"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "SUPPORT: 1000\n",
+      "Patron 1 supports\n",
+      "SUPPORT_PRICE (ETH whole for MKT whole): 11000000000000000000\n",
+      "MINTED: 0.000000\n",
+      "Patron 2 supports\n",
+      "SUPPORT_PRICE (ETH whole for MKT whole): 1111000000000000000000\n",
+      "MINTED: 0.000000\n",
+      "Patron 3 supports\n",
+      "SUPPORT_PRICE (ETH whole for MKT whole): 2211000000000000000000\n",
+      "MINTED: 0.000000\n",
+      "Patron 4 supports\n",
+      "SUPPORT_PRICE (ETH whole for MKT whole): 3311000000000000000000\n",
+      "MINTED: 0.000000\n",
+      "Patron 5 supports\n",
+      "SUPPORT_PRICE (ETH whole for MKT whole): 4411000000000000000000\n",
+      "MINTED: 0.000000\n",
+      "Patron 6 supports\n",
+      "SUPPORT_PRICE (ETH whole for MKT whole): 5511000000000000000000\n",
+      "MINTED: 0.000000\n",
+      "Patron 7 supports\n",
+      "SUPPORT_PRICE (ETH whole for MKT whole): 6611000000000000000000\n",
+      "MINTED: 0.000000\n",
+      "Patron 8 supports\n",
+      "SUPPORT_PRICE (ETH whole for MKT whole): 7711000000000000000000\n",
+      "MINTED: 0.000000\n",
+      "Patron 9 supports\n",
+      "SUPPORT_PRICE (ETH whole for MKT whole): 8811000000000000000000\n",
+      "MINTED: 0.000000\n",
+      "Patron 10 supports\n",
+      "SUPPORT_PRICE (ETH whole for MKT whole): 9911000000000000000000\n",
+      "MINTED: 0.000000\n",
+      "############################\n",
+      "MARKET_TOTAL: 0.000000\n",
+      "RESERVE: 10010.000000\n",
+      "coin_table\n",
+      "{'CREATOR': 0.0, 'PATRON_10': 0.0, 'PATRON_3': 0.0, 'PATRON_5': 0.0, 'PATRON_9': 0.0, 'PATRON_4': 0.0, 'PATRON_1': 0.0, 'PATRON_7': 0.0, 'PATRON_8': 0.0, 'PATRON_6': 0.0, 'PATRON_2': 0.0}\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"SUPPORT: %d\" % wei_to_whole(SUPPORT))\n",
+    "for i in range(N_PATRONS):\n",
+    "    print(\"Patron %d supports\" % (i+1))\n",
+    "    if MARKET_TOTAL < 1 * WHOLE:\n",
+    "        SUPPORT_PRICE = PRICE_FLOOR + ((SPREAD * RESERVE * GWEI) // (100 * 1 * WHOLE))\n",
+    "    else:\n",
+    "        SUPPORT_PRICE = PRICE_FLOOR + ((SPREAD * RESERVE * GWEI) // (100 * MARKET_TOTAL))\n",
+    "    print(\"SUPPORT_PRICE (ETH whole for MKT whole): %d\" % convert_support_price(SUPPORT_PRICE))\n",
+    "    MINTED = (SUPPORT // SUPPORT_PRICE) * GWEI # Units of WEI\n",
+    "    print(\"MINTED: %f\" % (MINTED / 10**18))\n",
+    "    MARKET_TOTAL += MINTED\n",
+    "    RESERVE += SUPPORT\n",
+    "    coin_table[\"PATRON_%d\" % (i+1)] = MINTED / 10**18\n",
+    "\n",
+    "print(\"############################\")\n",
+    "print(\"MARKET_TOTAL: %f\" % (MARKET_TOTAL / 10**18))\n",
+    "print(\"RESERVE: %f\" % (RESERVE / 10**18))\n",
+    "print(\"coin_table\")\n",
+    "print(coin_table)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/Initial Condition Analysis Fix.ipynb
+++ b/Initial Condition Analysis Fix.ipynb
@@ -71,7 +71,7 @@
     "# Initial creator transfer into reserve\n",
     "CREATOR_SUPPORT = 10 * WHOLE # ETH\n",
     "# Creator does their thing\n",
-    "CREATOR_BLOCK_SIZE = int(0 * WHOLE) # MKT"
+    "CREATOR_BLOCK_SIZE = int(1 * WHOLE) # MKT"
    ]
   },
   {
@@ -101,7 +101,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "MARKET_TOTAL: 0, RESERVE: 10\n"
+      "MARKET_TOTAL: 1, RESERVE: 10\n"
      ]
     }
    ],
@@ -137,40 +137,40 @@
      "text": [
       "SUPPORT: 1000\n",
       "Patron 1 supports\n",
-      "SUPPORT_PRICE (ETH whole for MKT whole): 11000000000000000000\n",
-      "MINTED: 0.000000\n",
+      "SUPPORT_PRICE (ETH whole for MKT whole): 11\n",
+      "MINTED: 90.900827\n",
       "Patron 2 supports\n",
-      "SUPPORT_PRICE (ETH whole for MKT whole): 1111000000000000000000\n",
-      "MINTED: 0.000000\n",
+      "SUPPORT_PRICE (ETH whole for MKT whole): 12\n",
+      "MINTED: 82.712175\n",
       "Patron 3 supports\n",
-      "SUPPORT_PRICE (ETH whole for MKT whole): 2211000000000000000000\n",
-      "MINTED: 0.000000\n",
+      "SUPPORT_PRICE (ETH whole for MKT whole): 12\n",
+      "MINTED: 78.968436\n",
       "Patron 4 supports\n",
-      "SUPPORT_PRICE (ETH whole for MKT whole): 3311000000000000000000\n",
-      "MINTED: 0.000000\n",
+      "SUPPORT_PRICE (ETH whole for MKT whole): 13\n",
+      "MINTED: 76.581703\n",
       "Patron 5 supports\n",
-      "SUPPORT_PRICE (ETH whole for MKT whole): 4411000000000000000000\n",
-      "MINTED: 0.000000\n",
+      "SUPPORT_PRICE (ETH whole for MKT whole): 13\n",
+      "MINTED: 74.844351\n",
       "Patron 6 supports\n",
-      "SUPPORT_PRICE (ETH whole for MKT whole): 5511000000000000000000\n",
-      "MINTED: 0.000000\n",
+      "SUPPORT_PRICE (ETH whole for MKT whole): 13\n",
+      "MINTED: 73.485344\n",
       "Patron 7 supports\n",
-      "SUPPORT_PRICE (ETH whole for MKT whole): 6611000000000000000000\n",
-      "MINTED: 0.000000\n",
+      "SUPPORT_PRICE (ETH whole for MKT whole): 13\n",
+      "MINTED: 72.373046\n",
       "Patron 8 supports\n",
-      "SUPPORT_PRICE (ETH whole for MKT whole): 7711000000000000000000\n",
-      "MINTED: 0.000000\n",
+      "SUPPORT_PRICE (ETH whole for MKT whole): 13\n",
+      "MINTED: 71.433865\n",
       "Patron 9 supports\n",
-      "SUPPORT_PRICE (ETH whole for MKT whole): 8811000000000000000000\n",
-      "MINTED: 0.000000\n",
+      "SUPPORT_PRICE (ETH whole for MKT whole): 14\n",
+      "MINTED: 70.622608\n",
       "Patron 10 supports\n",
-      "SUPPORT_PRICE (ETH whole for MKT whole): 9911000000000000000000\n",
-      "MINTED: 0.000000\n",
+      "SUPPORT_PRICE (ETH whole for MKT whole): 14\n",
+      "MINTED: 69.909586\n",
       "############################\n",
-      "MARKET_TOTAL: 0.000000\n",
+      "MARKET_TOTAL: 762.831940\n",
       "RESERVE: 10010.000000\n",
       "coin_table\n",
-      "{'CREATOR': 0.0, 'PATRON_10': 0.0, 'PATRON_3': 0.0, 'PATRON_5': 0.0, 'PATRON_9': 0.0, 'PATRON_4': 0.0, 'PATRON_1': 0.0, 'PATRON_7': 0.0, 'PATRON_8': 0.0, 'PATRON_6': 0.0, 'PATRON_2': 0.0}\n"
+      "{'PATRON_3': 78.968436364, 'PATRON_5': 74.844350524, 'PATRON_1': 90.900827197, 'PATRON_2': 82.712174511, 'PATRON_7': 72.373045728, 'PATRON_10': 69.909586479, 'PATRON_9': 70.622607795, 'PATRON_6': 73.485343754, 'PATRON_4': 76.581702925, 'CREATOR': 1.0, 'PATRON_8': 71.433864677}\n"
      ]
     }
    ],


### PR DESCRIPTION
This PR adds a notebook testing a proposed fix for https://github.com/computablelabs/goest/issues/122. In particular, it swaps the equation in https://github.com/computablelabs/computable/blob/master/contracts/Reserve.vy#L49 to work as follows:

```
SUPPORT_PRICE = PRICE_FLOOR + ((SPREAD * RESERVE * GWEI) // (100 * 1 * WHOLE))
```